### PR TITLE
added encoding to utf8 - to avoid UnicodeEncodeError

### DIFF
--- a/SendToPasteBin.py
+++ b/SendToPasteBin.py
@@ -69,7 +69,7 @@ class SendToPasteBinCommand( sublime_plugin.TextCommand ):
 
 			syntax = syntaxes.get(self.view.settings().get('syntax').split('/')[-1], 'text')
 
-			text = self.view.substr(region)
+			text = self.view.substr(region).encode('utf8')
 
 			if not text:
 				sublime.status_message('Error sending to PasteBin: Nothing selected')


### PR DESCRIPTION
added encoding to utf8 - to avoid UnicodeEncodeError when there are non-latin symbols in text i.e. cyryllic comments etc.

standart error message: "UnicodeEncodeError: 'ascii' codec can't encode characters in position ..."
