### PR TITLE
Missing import was fixed

### DIFF
--- a/SendToPasteBin.py
+++ b/SendToPasteBin.py
@@ -1,3 +1,5 @@
+import os
+
 import sublime, sublime_plugin
 from urllib import urlencode, urlopen
 


### PR DESCRIPTION
With recent update to Sublime Text 2.0.1 (Build 2117) the plugin stopped working because of the missing os module import. Fix is as simple as possible
